### PR TITLE
setup: extend git cli to use vmn on git-ver command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,8 @@ setuptools.setup(
     packages=[
         "version_stamp",
     ],
-    entry_points={"console_scripts": ["vmn = version_stamp.vmn:main"]},
+    entry_points={"console_scripts": [
+        "vmn = version_stamp.vmn:main",
+        "git-ver= version_stamp.vmn:main"
+    ]},
 )


### PR DESCRIPTION
When installing vmn we add another file which is called
`git-ver` by adding this file to the user PATH git will use
the file and allow the user to use the `git ver` command as if
`git-ver` is a builtin git cli command.